### PR TITLE
Update Grids with Inline-Editing

### DIFF
--- a/assets/components/clientconfig/js/mgr/widgets/grid.groups.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.groups.js
@@ -6,6 +6,8 @@ ClientConfig.grid.Groups = function(config) {
 		baseParams: {
             action: 'mgr/groups/getlist'
         },
+        save_action: 'mgr/groups/updatefromgrid',
+        autosave: true,
         emptyText: _('clientconfig.error.noresults'),
 		fields: [
             {name: 'id', type: 'int'},
@@ -24,17 +26,29 @@ ClientConfig.grid.Groups = function(config) {
 		},{
 			header: _('clientconfig.label'),
 			dataIndex: 'label',
+			editor: { xtype: 'textfield' },
 		    sortable: true,
 			width: .3
 		},{
 			header: _('clientconfig.description'),
 			dataIndex: 'description',
+			editor: { xtype: 'textfield' },
 			sortable: true,
 			width: .5
 		},{
 			header: _('clientconfig.settings_count'),
 			dataIndex: 'settings_count',
 		    sortable: true,
+			width: .1
+		},{
+			header: _('clientconfig.sortorder'),
+			dataIndex: 'sortorder',
+			editor: { 
+			    xtype: 'numberfield', 
+			    allowDecimal: false, 
+			    allowNegative: false 
+			},
+			sortable: true,
 			width: .1
 		}],
         tbar: [{

--- a/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
@@ -6,6 +6,8 @@ ClientConfig.grid.Settings = function(config) {
 		baseParams: {
             action: 'mgr/settings/getlist'
         },
+        save_action: 'mgr/settings/updatefromgrid',
+        autosave: true,
         emptyText: _('clientconfig.error.noresults'),
 		fields: [
             {name: 'id', type: 'int'},

--- a/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
@@ -33,11 +33,13 @@ ClientConfig.grid.Settings = function(config) {
 		},{
 			header: _('clientconfig.key'),
 			dataIndex: 'key',
+			editor: { xtype: 'textfield' },
 			sortable: true,
 			width: .3
 		},{
 			header: _('clientconfig.label'),
 			dataIndex: 'label',
+			editor: { xtype: 'textfield' },
 			sortable: true,
 			width: .3
 		},{

--- a/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
@@ -31,31 +31,36 @@ ClientConfig.grid.Settings = function(config) {
 		},{
 			header: _('clientconfig.key'),
 			dataIndex: 'key',
-		    sortable: true,
+			sortable: true,
 			width: .3
 		},{
 			header: _('clientconfig.label'),
 			dataIndex: 'label',
-		    sortable: true,
+			sortable: true,
 			width: .3
 		},{
 			header: _('clientconfig.xtype'),
 			dataIndex: 'xtype',
 			sortable: true,
-			width: .3
+			width: .15
 		},{
 			header: _('clientconfig.is_required'),
 			dataIndex: 'is_required',
-            sortable: true,
-			width: .1,
+			sortable: true,
+			width: .15,
 			renderer: this.rendYesNo
 		},{
 			header: _('clientconfig.group'),
 			dataIndex: 'group_label',
-		    sortable: true,
+			sortable: true,
 			width: .3
+		},{
+			header: _('clientconfig.sortorder'),
+			dataIndex: 'sortorder',
+			sortable: true,
+			width: .2
 		}],
-        tbar: [{
+	tbar: [{
             text: _('clientconfig.add_setting'),
             handler: this.addSetting,
             scope: this

--- a/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
@@ -61,6 +61,11 @@ ClientConfig.grid.Settings = function(config) {
 		},{
 			header: _('clientconfig.sortorder'),
 			dataIndex: 'sortorder',
+			editor: { 
+			    xtype: 'numberfield', 
+			    allowDecimal: false, 
+			    allowNegative: false 
+			},
 			sortable: true,
 			width: .2
 		}],

--- a/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/grid.settings.js
@@ -1,6 +1,8 @@
 ClientConfig.grid.Settings = function(config) {
     config = config || {};
-    Ext.applyIf(config,{
+    Ext.applyIf(config, {
+        
+        // Basic Grid Configuration
 		url: ClientConfig.config.connectorUrl,
 		id: 'clientconfig-grid-settings',
 		baseParams: {
@@ -9,6 +11,10 @@ ClientConfig.grid.Settings = function(config) {
         save_action: 'mgr/settings/updatefromgrid',
         autosave: true,
         emptyText: _('clientconfig.error.noresults'),
+        paging: true,
+		remoteSort: true,
+        
+        // Available Fields
 		fields: [
             {name: 'id', type: 'int'},
             {name: 'key', type: 'string'},
@@ -23,8 +29,8 @@ ClientConfig.grid.Settings = function(config) {
             {name: 'sortorder', type: 'int'},
             {name: 'options', type: 'object'}
         ],
-        paging: true,
-		remoteSort: true,
+		
+		// Visible Columns
 		columns: [{
 			header: _('clientconfig.id'),
 			dataIndex: 'id',
@@ -45,17 +51,29 @@ ClientConfig.grid.Settings = function(config) {
 		},{
 			header: _('clientconfig.xtype'),
 			dataIndex: 'xtype',
+			editor: { 
+			    xtype: 'clientconfig-combo-fieldtypes',
+			    renderer: true
+			},
 			sortable: true,
 			width: .15
 		},{
 			header: _('clientconfig.is_required'),
 			dataIndex: 'is_required',
+			editor: { 
+			    xtype: 'combo-boolean',
+			    renderer: 'boolean'
+			},
 			sortable: true,
 			width: .15,
 			renderer: this.rendYesNo
 		},{
 			header: _('clientconfig.group'),
-			dataIndex: 'group_label',
+			dataIndex: 'group',
+			editor: { 
+			    xtype: 'clientconfig-combo-groups',
+			    renderer: true
+			},
 			sortable: true,
 			width: .3
 		},{
@@ -69,7 +87,9 @@ ClientConfig.grid.Settings = function(config) {
 			sortable: true,
 			width: .2
 		}],
-	tbar: [{
+		
+		// Top-Bar
+        tbar: [{
             text: _('clientconfig.add_setting'),
             handler: this.addSetting,
             scope: this

--- a/core/components/clientconfig/processors/mgr/groups/updatefromgrid.class.php
+++ b/core/components/clientconfig/processors/mgr/groups/updatefromgrid.class.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Updates a cgGroup object from the grid
+ */
+require_once (dirname(__FILE__).'/update.class.php');
+
+class cgGroupUpdateFromGridProcessor extends cgGroupUpdateProcessor {
+    public function initialize() {
+        $data = $this->getProperty('data');
+        if (empty($data)) return $this->modx->lexicon('invalid_data');
+        $data = $this->modx->fromJSON($data);
+        if (empty($data)) return $this->modx->lexicon('invalid_data');
+        $this->setProperties($data);
+        $this->unsetProperty('data');
+        return parent::initialize();
+    }
+}
+
+return 'cgGroupUpdateFromGridProcessor';

--- a/core/components/clientconfig/processors/mgr/settings/updatefromgrid.class.php
+++ b/core/components/clientconfig/processors/mgr/settings/updatefromgrid.class.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Updates a cgSetting object from the grid
+ */
+require_once (dirname(__FILE__).'/update.class.php');
+
+class cgSettingUpdateFromGridProcessor extends cgSettingUpdateProcessor {
+    public function initialize() {
+        $data = $this->getProperty('data');
+        if (empty($data)) return $this->modx->lexicon('invalid_data');
+        $data = $this->modx->fromJSON($data);
+        if (empty($data)) return $this->modx->lexicon('invalid_data');
+        $this->setProperties($data);
+        $this->unsetProperty('data');
+        return parent::initialize();
+    }
+}
+
+return 'cgSettingUpdateFromGridProcessor';


### PR DESCRIPTION
Show the sort orders on the admin table, 
taking care partially of #95. 

Also the column-widths are re-configured.
