### PR TITLE
Update firing event to OnMODXInit

### DIFF
--- a/_build/events/events.clientconfig.php
+++ b/_build/events/events.clientconfig.php
@@ -3,7 +3,7 @@
 $events = array();
 
 $e = array(
-    'OnHandleRequest',
+    'OnMODXInit',
 );
 
 foreach ($e as $ev) {

--- a/core/components/clientconfig/elements/plugins/clientconfig.plugin.php
+++ b/core/components/clientconfig/elements/plugins/clientconfig.plugin.php
@@ -33,7 +33,7 @@
 $eventName = $modx->event->name;
 
 switch($eventName) {
-    case 'OnHandleRequest':
+    case 'OnMODXInit':
         /* Grab the class */
         $path = $modx->getOption('clientconfig.core_path', null, $modx->getOption('core_path') . 'components/clientconfig/');
         $path .= 'model/clientconfig/';


### PR DESCRIPTION
Changing from firing OnHandleRequest to OnMODXInit has been shown to make the setting available as placeholders and via $modx->getOptions() calls in more places. The test case has been a MIGX form loading a TV which runs an EVAL to retrieve settings.
