### PR TITLE
Attempt adding a multi checkbox field #143

### DIFF
--- a/assets/components/clientconfig/js/mgr/sections/home.js
+++ b/assets/components/clientconfig/js/mgr/sections/home.js
@@ -128,6 +128,30 @@ Ext.extend(ClientConfig.page.Home,MODx.Component,{
                     field.value = 1;
                     field.checked = (value.value);
                 }
+                if (field.xtype === 'multi-checkbox') {
+                    field.xtype = 'checkboxgroup';
+                    field.columns = 1;
+                    field.items = [{xtype: 'checkbox', boxLabel: 'foo', 'name': 'foo'}];
+
+                    var options = value.options.split('||');
+                    Ext.each(options, function(option, index) {
+                        option = option.split('==');
+                        if (option[1]) {
+                            field.items.push({
+                                boxLabel: option[0],
+                                value: option[1],
+                                name: field.name + '[]'
+                            })
+                        } else {
+                            field.items.push({
+                                boxLabel: option[0],
+                                value: option[0],
+                                name: field.name + '[]'
+                            })
+                        }
+                    });
+                    console.log(field);
+                }
 
                 if (field.xtype == 'datefield') {
                     field.format = MODx.config.manager_date_format;

--- a/assets/components/clientconfig/js/mgr/widgets/combos.js
+++ b/assets/components/clientconfig/js/mgr/widgets/combos.js
@@ -44,6 +44,7 @@ ClientConfig.combo.FieldTypes = function(config) {
                 ['colorpickerfield', _('clientconfig.xtype.colorpalette')],
                 ['email', _('clientconfig.xtype.email')],
                 ['xcheckbox', _('clientconfig.xtype.xcheckbox')],
+                ['multi-checkbox', _('clientconfig.xtype.multi-checkbox')],
                 ['datefield', _('clientconfig.xtype.datefield')],
                 ['timefield', _('clientconfig.xtype.timefield')],
                 ['password', _('clientconfig.xtype.password')],

--- a/assets/components/clientconfig/js/mgr/widgets/window.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/window.settings.js
@@ -71,7 +71,7 @@ ClientConfig.window.Setting = function(config) {
                     anchor: '100%',
                     listeners: {
                         select: {fn: function(field, record) {
-                            if (record.data.xtype == 'modx-combo') {
+                            if (['modx-combo', 'multi-checkbox'].indexOf(record.data.xtype) !== -1) {
                                 Ext.getCmp(config.id + '-options').show();
                                 Ext.getCmp(config.id + '-process_options').show();
                             } else {
@@ -97,7 +97,7 @@ ClientConfig.window.Setting = function(config) {
                     fieldLabel: _('clientconfig.options'),
                     description: _('clientconfig.options.desc'),
                     anchor: '100%',
-                    hidden: (config.record && (config.record.xtype === 'modx-combo')) ? false : true
+                    hidden: (config.record && (['modx-combo', 'multi-checkbox'].indexOf(config.record.xtype) !== -1)) ? false : true
                 },{
                     xtype: 'checkbox',
                     id: config.id + '-process_options',

--- a/core/components/clientconfig/controllers/home.class.php
+++ b/core/components/clientconfig/controllers/home.class.php
@@ -41,7 +41,7 @@ class ClientConfigHomeManagerController extends ClientConfigManagerController {
                     $googleFontsApiKey = $this->modx->getOption('clientconfig.google_fonts_api_key', null, '');
                     $sa['xtype'] = empty($googleFontsApiKey) ? 'textfield' : $sa['xtype'];
                 }
-                elseif ($sa['xtype'] === 'modx-combo' && $setting->get('process_options')) {
+                elseif ($setting->get('process_options') && in_array($sa['xtype'], ['modx-combo', 'multi-checkbox'], true)) {
                     $inputOpts = $setting->get('options');
                     $this->modx->getParser();
                     $this->modx->parser->processElementTags('', $inputOpts, true, true);

--- a/core/components/clientconfig/lexicon/en/default.inc.php
+++ b/core/components/clientconfig/lexicon/en/default.inc.php
@@ -113,3 +113,4 @@ $_lang['clientconfig.process_options'] = 'Process tags in options';
 $_lang['clientconfig.xtype.line'] = 'Line (divider)';
 $_lang['clientconfig.xtype.code'] = 'Code (requires Ace editor installed)';
 $_lang['clientconfig.xtype.email'] = 'Email';
+$_lang['clientconfig.xtype.multi-checkbox'] = 'Multiple checkboxes';


### PR DESCRIPTION
In progress. Throws a JS error due `field.items` for some reason.

```
utilities.js:67 Uncaught TypeError: nodeToRecurse.items.each is not a function
    at constructor.clearDirty (utilities.js:67)
    at constructor.<anonymous> (utilities.js:71)
    at Ext.util.MixedCollection.each (ext-all.js:21)
    at constructor.clearDirty (utilities.js:67)
    at MODx.FormPanel.clearDirty (modx.panel.js:210)
    at new MODx.FormPanel (modx.panel.js:63)
    at Object.create (ext-all.js:21)
    at S.createComponent (ext-all.js:21)
    at S.lookupComponent (ext-all.js:21)
    at S.add (ext-all.js:21)
    at S.<anonymous> (ext-all.js:21)
    at Object.each (ext-base.js:21)
    at S.add (ext-all.js:21)
    at S.initComponent (ext-all.js:21)
    at S.initComponent (ext-all.js:21)
    at S.Ext.Component [as constructor] (ext-all.js:21)
    at S [as constructor] (ext-base.js:21)
    at S [as constructor] (ext-base.js:21)
    at new S (ext-base.js:21)
    at Object.create (ext-all.js:21)
    at MODx.load (modx.js?v=01800b12:85)
    at ClientConfig.page.Home._loadComponents (modx.component.js:68)
    at ClientConfig.page.Home.MODx.Component [as constructor] (modx.component.js:10)
    at new ClientConfig.page.Home (home.js:60)
    at Object.create (ext-all.js:21)
    at MODx.load (modx.js?v=01800b12:85)
    at ?a=home&namespace=clientconfig:159
    at ext-all.js:21
    at b (ext-all.js:21)
```

#143